### PR TITLE
gfortran_impl_osx-64 14.3.0 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,21 +4,16 @@ cxx_compiler_version:   # [osx]
   - 17                  # [osx]
 
 macos_machine:
-  - x86_64-apple-darwin13.4.0
   - arm64-apple-darwin20.0.0
 cross_target_platform:
-  - osx-64
   - osx-arm64
 gfortran_version:
   - 15.2.0
   - 14.3.0
-  - 13.4.0
 gfortran_maj_ver:
   - 15
   - 14
-  - 13
 libgfortran_soversion:
-  - 5
   - 5
   - 5
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -147,7 +147,7 @@ outputs:
         - gmp
         - zlib
         - libiconv
-        - cctools_{{ cross_target_platform }}
+        - cctools  # _{{ cross_target_platform }}
         - clang
     files:
       - bin/gfortran   # [target_platform == cross_target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,6 +117,13 @@ outputs:
     build:
       activate_in_script: True
       skip: True  # [win]
+      missing_dso_whitelist:        # [osx]
+        - '$RPATH/libz.1.dylib'     # [osx]
+        - '$RPATH/libiconv.2.dylib' # [osx]
+        - '$RPATH/libisl.22.dylib'  # [osx]
+        - '$RPATH/libmpc.3.dylib'   # [osx]
+        - '$RPATH/libmpfr.6.dylib'  # [osx]
+        - '$RPATH/libgmp.10.dylib'  # [osx]
     requirements:
       build:
         - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -245,11 +245,14 @@ outputs:
         - test -f "${PREFIX}/lib/libgcc_s.1.1.dylib"
 
 about:
-  home: http://gcc.gnu.org/
+  home: https://gcc.gnu.org/
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   license_file: COPYING3
   summary: Fortran compiler and libraries from the GNU Compiler Collection
+  description: Fortran compiler and libraries from the GNU Compiler Collection
+  doc_url: https://gcc.gnu.org/onlinedocs/
+  dev_url: https://gcc.gnu.org/git/gcc.git
 
 extra:
   feedstock-name: gfortran_impl_osx-64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
 build:
   number: {{ build_number }}
   # we don't need to cross-compile to osx from anything but osx or linux-64
-  skip: true  # [not (osx or linux64)]
+  skip: true  # [not osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -116,7 +116,7 @@ outputs:
     version: {{ gfortran_version }}
     build:
       activate_in_script: True
-      skip: True  # [win]
+      skip: True  # [not osx]
       missing_dso_whitelist:        # [osx]
         - '$RPATH/libz.1.dylib'     # [osx]
         - '$RPATH/libiconv.2.dylib' # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,12 +49,12 @@ requirements:
     - mpc       # [build_platform != target_platform]
     - coreutils  # [osx]
   host:
-    - libiconv
-    - zlib
-    - gmp
-    - mpfr
-    - isl
-    - mpc
+    - libiconv {{ libiconv }}
+    - zlib {{ zlib }}
+    - gmp {{ gmp }}
+    - mpfr {{ mpfr }}
+    - isl {{ isl }}
+    - mpc {{ mpc }}
 
 test:
   files:
@@ -139,12 +139,12 @@ outputs:
         - isl       # [build_platform != target_platform]
         - mpc       # [build_platform != target_platform]
       host:
-        - libiconv
-        - zlib
-        - gmp
-        - mpfr
-        - isl
-        - mpc
+        - libiconv {{ libiconv }}
+        - zlib {{ zlib }}
+        - gmp {{ gmp }}
+        - mpfr {{ mpfr }}
+        - isl {{ isl }}
+        - mpc {{ mpc }}
       run:
         - libgfortran{{ libgfortran_soversion }} >={{ gfortran_version }}  # [target_platform == cross_target_platform]
         - libgfortran-devel_{{ target_platform }} {{ gfortran_version }}       # [target_platform == cross_target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,7 +154,8 @@ outputs:
         - gmp
         - zlib
         - libiconv
-        - cctools  # _{{ cross_target_platform }}
+        # our cctools_{{ cross_target_platform }} is out of date
+        - cctools
         - clang
     files:
       - bin/gfortran   # [target_platform == cross_target_platform]


### PR DESCRIPTION
gfortran_impl_osx-64 14.3.0 

**Destination channel:** Defaults

### Links

- [PKG-10748]
- dev_url:        https://gcc.gnu.org/git/?p=gcc.git;a=tree
- conda_forge:    https://github.com/conda-forge/gfortran_impl_osx-64-feedstock
- pypi:           https://pypi.org/project/gfortran_impl_osx-64/14.3.0
- pypi inspector: https://inspector.pypi.io/project/gfortran_impl_osx-64/14.3.0

### Explanation of changes:

- resync with CF
- restrict `cbc.yaml` to just `osx-arm64` and versions `15.2.0` and `.14.3.0`
- restrict build to just `osx`
- depend on the "depending on clang-20" `cctools` (rather than `cctools_osx-arm64` which is llvm12)

For testing see https://github.com/AnacondaRecipes/gfortran_osx-64-feedstock/pull/6


[PKG-10748]: https://anaconda.atlassian.net/browse/PKG-10748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ